### PR TITLE
Potential fix for code scanning alert no. 22: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 env:
   NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
   NEXT_PUBLIC_FACEBOOK_APP_ID: ${{ vars.NEXT_PUBLIC_FACEBOOK_APP_ID }}

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -2,6 +2,9 @@
 
 name: Manual workflow
 
+permissions:
+  contents: read
+
 # Controls when the action will run. Workflow runs when manually triggered using the UI
 # or API.
 on:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 env:
   NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
   NEXT_PUBLIC_FACEBOOK_APP_ID: ${{ vars.NEXT_PUBLIC_FACEBOOK_APP_ID }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 env:
   NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
   NEXT_PUBLIC_FACEBOOK_APP_ID: ${{ vars.NEXT_PUBLIC_FACEBOOK_APP_ID }}


### PR DESCRIPTION
Potential fix for [https://github.com/gs377209/bestseenonfoot/security/code-scanning/22](https://github.com/gs377209/bestseenonfoot/security/code-scanning/22)

Add an explicit `permissions` block to `.github/workflows/playwright.yml` at the workflow root so it applies to all jobs (currently there is one job). The minimal safe baseline recommended by CodeQL is `contents: read`, which supports repository checkout while preventing unnecessary write access for `GITHUB_TOKEN`. This does not change intended functionality for this test workflow.

Change region: immediately after the `on:` trigger section (after line 8 in the provided snippet), add:

- `permissions:`
- `contents: read`

No imports, methods, or additional definitions are needed (YAML workflow file only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
